### PR TITLE
WIP: adding model download job and pvc option for vllm-kserve

### DIFF
--- a/charts/vllm-kserve/README.md
+++ b/charts/vllm-kserve/README.md
@@ -99,6 +99,26 @@ helm upgrade -i [release-name] redhat-ai-services/vllm-kserve \
   --set model.uri="pvc://{pvc-name}/{model-folder}"
 ```
 
+#### PVC Storage - Create PVC and Download Model into PVC
+
+As mentioned above, the InferenceService can read a model from a PVC. This chart has the ability download a model from HuggingFace and download it into a PVC. In the InferenceService, the `storageUri` will be set automatically to read the model from this new PVC.
+
+To create a PVC and download a model from HuggingFace into it, and then bring up the Inference Service, you can provide the following options:
+
+```sh
+helm upgrade -i [release-name] redhat-ai-services/vllm-kserve \
+  --set model.mode=pvc \
+  --set model.pvc.name=granite-3.3-8b-instruct-pvc \
+  --set model.pvc.createPvc.enabled=true \
+  --set model.pvc.createPvc.size=35Gi \
+  --set model.pvc.createPvc.storageClass=gp3-csi \
+  --set model.pvc.downloadModel.enabled=true \
+  --set model.pvc.downloadModel.huggingfaceModelRepo="ibm-granite/granite-3.3-8b-instruct" \
+  --set model.pvc.downloadModel.huggingfaceToken="your-token-here" \
+  --set model.pvc.downloadModel.allowPatterns="*.safetensors,*.json,*.txt"
+```
+
+
 ### S3 Storage
 
 Deploy models from S3-compatible storage by providing S3 credentials:

--- a/charts/vllm-kserve/templates/_helpers.tpl
+++ b/charts/vllm-kserve/templates/_helpers.tpl
@@ -163,3 +163,12 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+
+{{- define "vllm-kserve.hugginfaceGitUrl" -}}
+{{- if .Values.model.pvc.downloadModel.huggingfaceModelRepo | hasPrefix "https://huggingface.co/" }}
+{{- printf "%s" .Values.model.pvc.downloadModel.huggingfaceModelRepo }}
+{{- else }}
+{{- printf "https://huggingface.co/%s" .Values.model.pvc.downloadModel.huggingfaceModelRepo }}
+{{- end }}
+{{- end }}

--- a/charts/vllm-kserve/templates/_validaters.tpl
+++ b/charts/vllm-kserve/templates/_validaters.tpl
@@ -46,7 +46,7 @@ Validate that multi-node topology is only used with RawDeployment mode.
 Validate that a valid model mode is configured.
 */}}
 {{- define "vllm-kserve.validateModelMode" -}}
-{{- $validModes := list "uri" "s3" }}
+{{- $validModes := list "uri" "s3" "pvc" }}
 {{- if not (has (lower .Values.model.mode) $validModes) }}
     {{- fail (printf "Invalid model.mode. Must be one of: %s" $validModes) }}
 {{- end }}

--- a/charts/vllm-kserve/templates/downloadmodeljob.yaml
+++ b/charts/vllm-kserve/templates/downloadmodeljob.yaml
@@ -1,0 +1,39 @@
+{{- if .Values.model.pvc.createPvc.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: download-model-from-hf
+  annotations:
+    helm.sh/hook-weight: "-1"
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/resource-policy: keep
+spec:
+  template:
+    spec:
+      volumes:
+        - name: model-volume
+          persistentVolumeClaim:
+            claimName: {{ .Values.model.pvc.name }}
+      containers:
+        - name: download-model-from-hf
+          image: alpine/git:2.43.0
+          env:
+            - name: MODEL_REPO
+              value: {{ include "vllm-kserve.hugginfaceGitUrl" . }}
+            - name: TARGET_DIR
+              value: /data/models/{{ .Values.model.pvc.downloadModel.huggingfaceModelRepo }}
+            - name: ALLOW_PATTERNS
+              value: "{{ .Values.model.pvc.downloadModel.allowPatterns }}"
+            - name: HF_TOKEN
+              value: {{ .Values.model.pvc.downloadModel.huggingfaceToken }}
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              git clone --single-branch -- $MODEL_REPO $TARGET_DIR 
+              ls -la $TARGET_DIR
+          volumeMounts:
+            - name: model-volume
+              mountPath: /data/models
+      restartPolicy: Never
+  backoffLimit: 0
+{{- end }}

--- a/charts/vllm-kserve/templates/inferenceservice.yaml
+++ b/charts/vllm-kserve/templates/inferenceservice.yaml
@@ -86,6 +86,8 @@ spec:
       {{- with .Values.model }}
       {{- if eq (lower .mode) "uri" }}
       storageUri: {{ .uri }}
+      {{- else if eq (lower .mode) "pvc"}}
+      storageUri: pvc://{{ .pvc.name }}/data/models/{{ .pvc.downloadModel.huggingfaceModelRepo }}
       {{- else if eq (lower .mode) "s3"}}
       storage:
         key: {{ .s3.key }}

--- a/charts/vllm-kserve/templates/pvc.yaml
+++ b/charts/vllm-kserve/templates/pvc.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.model.pvc.createPvc.enabled }}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ .Values.model.pvc.name }}
+  annotations:
+    helm.sh/hook-weight: "-10"
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/resource-policy: keep
+  labels:
+    {{- include "vllm-kserve.labels" $ | nindent 4 }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.model.pvc.createPvc.size }}
+  storageClassName: {{ .Values.model.pvc.createPvc.storageClass }}
+  volumeMode: Filesystem
+{{- end }}

--- a/charts/vllm-kserve/values.yaml
+++ b/charts/vllm-kserve/values.yaml
@@ -32,7 +32,9 @@ model:
     # - name: VLLM_LOGGING_LEVEL
     #   value: INFO
 
-  # -- Option to set how the storage will be configured.  Options: "uri" and "s3"
+  # -- Option to set how the storage will be configured.  Options: "uri" and "s3" and "pvc". 
+  # If set to "pvc", the uri will be set automatically from model.pvc elements
+  # If pvc already exists and model already downloaded to pvc, set mode to "uri" and update uri to pvc://<pvc-name>/<path-to-model>
   mode: uri
 
   # -- The Uri to use for storage.  Mode must be set to "uri" to use this option.  Options: "oci://" and "pvc://"
@@ -44,6 +46,19 @@ model:
 
     # -- The containing the model in the s3 bucket.  Mode must be set to "s3" to use this option.
     path: ""
+
+  pvc: 
+    # Create PVC for model download and download the model from huggingface.
+    name: granite-3.3-8b-instruct-pvc
+    createPvc:
+      enabled: false
+      size: 25Gi
+      storageClass: gp3-csi
+    downloadModel:
+      enabled: false
+      huggingfaceModelRepo: "ibm-granite/granite-3.3-8b-instruct"
+      huggingfaceToken: your-token-here
+      allowPatterns: "*.safetensors,*.json,*.txt"
 
 endpoint:
   externalRoute:


### PR DESCRIPTION
Adding option to download a model from hugging face into a PVC.

The download model job is using alpine/git as the base container and using a git clone. This does not take into account hugging face repos that need a token to download a model. We may want to change the command to handle it: `git clone https://username:token@huggingface.co/org/model`

Looking for feedback on the job container. Using git clone works, but looking for ideas on others.
The [model-car](https://github.com/redhat-ai-services/modelcar-catalog/tree/main/builder-images/huggingface-modelcar-builder) image is still giving permission denied.